### PR TITLE
deleted superfluous stuff

### DIFF
--- a/report/sections/introduction/semester-roles.tex
+++ b/report/sections/introduction/semester-roles.tex
@@ -21,7 +21,7 @@ There were some well defined tasks for the process group which were:
 \noindent
 
 \subsection{Product Owner Group}
-Our role this semester was to function as product owners of the GIRAF project and to be in charge of customer contact. 
+Our role this semester was to function as product owners of the GIRAF project and to be responsible for customer contact. 
 As product owners, we strove to have interviews with the customers at the end of every sprint to get feedback and conduct usability tests on the product.
 The primary goal for our group was to maximize the value of the application for the customers. 
 This was done by prioritizing user stories so that the customers got as much value as possible \autocite{TheScrumGuide}.\\
@@ -37,4 +37,3 @@ There were some well defined tasks for the product owner group, which were:
     \item Approve or decline features made by the development teams
     \item Conduct usability tests
 \end{itemize}
-\noindent

--- a/report/sections/introduction/semester-roles.tex
+++ b/report/sections/introduction/semester-roles.tex
@@ -12,17 +12,13 @@ They arranged meetings and tried to optimize the meetings to avoid wasting time.
 \\
 There were some well defined tasks for the process group which were:
 \begin{itemize}
-    \item Deciding process changes during the semester
+    \item Decide process changes during the semester
     \item Host the sprint planning meetings
     \item Facilitate stand up meetings for all groups
     \item Plan the first skill group meetings
     \item Host the sprint retrospective meetings
 \end{itemize}
 \noindent
-The process group decided the initial processes for this semester based on feedback and discussions with all GIRAF members.
-During the semester they evaluated the process model to investigate if the process worked as optimally as possible.
-\\
-15 minutes were allocated for stand up meetings, and it was the responsibility of the process group that they did not go over time.
 
 \subsection{Product Owner Group}
 Our role this semester was to function as product owners of the GIRAF project and to be in charge of customer contact. 
@@ -42,15 +38,4 @@ There were some well defined tasks for the product owner group, which were:
     \item Conduct usability tests
 \end{itemize}
 \noindent
-The interviews were the foundation for understanding the requirements of the program and were used to create user stories. 
-Prototypes were created for the user stories.
-These prototypes were used to create an initial design for the new features that the user stories might include. 
-This was done so that we had a visual presentation of the user stories which made it easier for us to communicate with the customers and make sure that we understood each other. 
-This way we could get a confirmation that the design ideas we had been working on satisfied the needs of the customer.
-When the prototypes were approved by the customer they were added to the user stories in the backlog, so that the development teams could use them as a frame of reference when implementing them.
-\\\\
-At the start of every sprint we defined a vision for the sprint, defined sprint goals and updated the backlog. 
-The vision and sprint goals were made to ensure that every team knew what they were working towards, and to motivate them to deliver a good product.
-When a sprint ended, a usability test was conducted on the newest release to test new features and to get feedback in order to determine what should be developed next, and whether or not the new functionality was acceptable.
-
 

--- a/report/sections/introduction/semester-roles.tex
+++ b/report/sections/introduction/semester-roles.tex
@@ -18,7 +18,6 @@ There were some well defined tasks for the process group which were:
     \item Plan the first skill group meetings
     \item Host the sprint retrospective meetings
 \end{itemize}
-\noindent
 
 \subsection{Product Owner Group}
 Our role this semester was to function as product owners of the GIRAF project and to be responsible for customer contact. 


### PR DESCRIPTION
Fixes double description of relationship between prototypes and uiser stories.

Closes the issue about going more in depth on 1.6.2.
What was in that section was a description of the prototype relations and some random not very in depth thoughts about some of the items in the itemize. I think this should be deleted to save space, as the thinkgs written were just the same as the sections when these tasks are actually carried out by us.
I also deleted some stuff related to the scrum group, as it felt like it was a weird unnecessary inclusion.